### PR TITLE
V0.1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]## [0.1.2.2b]
+## [Unreleased]## [0.1.2.2b1]
+
+## [0.1.2.2b0] - 2022-09-22
 ### Changed
 - Stop Server button now uses os.kill() instead of deprecated Werkzeug callback
 
-## [0.1.2.1] - 2002-04-28
+## [0.1.2.1] - 2022-04-28
 ### Changed
 ### Added
 - Customize the 'brand' name of the dashboard by overriding DashApp.get_navbar_brand_children

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]## [0.1.2.1b0]
+## [Unreleased]## [0.1.2.2b]
 ### Changed
 
 ## [0.1.2.1] - 2002-04-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]## [0.1.2.2b]
 ### Changed
+- Stop Server button now uses os.kill() instead of deprecated Werkzeug callback
 
 ## [0.1.2.1] - 2002-04-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]## [0.1.2.2b1]
+## [Unreleased]## [0.1.2.2b2]
+
+## [0.1.2.2b1] - 2022-10-17
+### Changed
+- DashApp.run_server(self, **kwargs) with arguments for dash app.run_server()
+### Removed
+- DashApp.set_run_server_kwargs()
 
 ## [0.1.2.2b0] - 2022-09-22
 ### Changed
 - Stop Server button now uses os.kill() instead of deprecated Werkzeug callback
-- DashApp.run_server(self, **kwargs) with arguments for dash app.run_server()
-### Removed
-- DashApp.set_run_server_kwargs()
 
 ## [0.1.2.1] - 2022-04-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - DoDashApp.read_scenario_tables_from_db_cached only reads tables in the schema, skips others without warning.
 - Enabled virtualization in DashTables (Prepare data and Explore Solution)
+- Removed unused import in dash_common_utils causing failure in PyCharm debug mode
 
 ## [0.1.2.2b1] - 2022-10-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]## [0.1.2.2b2]
+### Changed
+- DoDashApp.read_scenario_tables_from_db_cached only reads tables in the schema, skips others without warning.
 
 ## [0.1.2.2b1] - 2022-10-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]## [0.1.2.2b2]
 ### Changed
 - DoDashApp.read_scenario_tables_from_db_cached only reads tables in the schema, skips others without warning.
+- Enabled virtualization in DashTables (Prepare data and Explore Solution)
 
 ## [0.1.2.2b1] - 2022-10-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.2.2b1] - 2022-10-17
 ### Changed
 - DashApp.run_server(self, **kwargs) with arguments for dash app.run_server()
+- Enabled write output to DB after run model.
 ### Removed
 - DashApp.set_run_server_kwargs()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]## [0.1.2.2b3]
 ### Changed
 - setup.py avoids import of dse_do_utils to get __version__
+- Removed unused import in dash_common_utils causing failure in PyCharm debug mode
 
 ## [0.1.2.2b2] - 2022-11-15
 ### Changed
 - DoDashApp.read_scenario_tables_from_db_cached only reads tables in the schema, skips others without warning.
 - Enabled virtualization in DashTables (Prepare data and Explore Solution)
 - Remove restriction on SQLAlchemy version < 1.4
-- Removed unused import in dash_common_utils causing failure in PyCharm debug mode
 
 ## [0.1.2.2b1] - 2022-10-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.2.2b0] - 2022-09-22
 ### Changed
 - Stop Server button now uses os.kill() instead of deprecated Werkzeug callback
+- DashApp.run_server(self, **kwargs) with arguments for dash app.run_server()
+### Removed
+- DashApp.set_run_server_kwargs()
 
 ## [0.1.2.1] - 2022-04-28
 ### Changed

--- a/dse_do_dashboard/dash_app.py
+++ b/dse_do_dashboard/dash_app.py
@@ -69,7 +69,8 @@ class DashApp(ABC):
         self.run_server_kwargs: Dict = {}  # {"host": "localhost"}
 
     def set_run_server_kwargs(self, **run_server_kwargs):
-        """Use to set input arguments for Dash.run_server(), in addition to `debug` and `port`.
+        """DEPRECATED (also non-functional). Use `self.run_server(self, **kwargs)` to pass additional arguments.
+        Use to set input arguments for Dash.run_server(), in addition to `debug` and `port`.
         For instance, running locally on a Mac requires host='localhost'. """
         if run_server_kwargs is not None:
             self.run_server_kwargs = run_server_kwargs
@@ -112,15 +113,32 @@ class DashApp(ABC):
         app.config.suppress_callback_exceptions = True
         return app
 
-    def run_server(self):
-        """Runs the Dash server.
+    def run_server(self, **kwargs):
+        '''
+        Runs the Dash server.
         To be called from index.py::
 
             if __name__ == '__main__':
                 DA.run_server()
 
-        """
-        self.app.run_server(debug=self.dash_debug, port=self.port, **self.run_server_kwargs)
+        '''
+
+        if 'debug' not in kwargs:
+            kwargs['debug'] = self.dash_debug
+        if 'port' not in kwargs:
+            kwargs['port'] = self.port
+
+        self.app.run_server(**kwargs)
+
+    # def run_server(self):
+    #     """Runs the Dash server.
+    #     To be called from index.py::
+    #
+    #         if __name__ == '__main__':
+    #             DA.run_server()
+    #
+    #     """
+    #     self.app.run_server(debug=self.dash_debug, port=self.port, **self.run_server_kwargs)
 
     def config_cache(self):
         self.cache = Cache()

--- a/dse_do_dashboard/dash_app.py
+++ b/dse_do_dashboard/dash_app.py
@@ -1,6 +1,6 @@
 # Copyright IBM All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
+import signal
 from abc import ABC
 from typing import Dict, Optional, List
 
@@ -481,11 +481,12 @@ class DashApp(ABC):
         """Shuts-down the Flash web-server, releasing the port.
         Relevant in CPD, so the port gets released immediately.
         """
-        from flask import request
-        func = request.environ.get('werkzeug.server.shutdown')
-        if func is None:
-            raise RuntimeError('Not running with the Werkzeug Server')
-        func()
+        os.kill(os.getpid(), signal.SIGTERM)
+        # from flask import request
+        # func = request.environ.get('werkzeug.server.shutdown')
+        # if func is None:
+        #     raise RuntimeError('Not running with the Werkzeug Server')
+        # func()
 
     def get_table_schema(self, table_name) -> Optional[ScenarioTableSchema]:
         pass

--- a/dse_do_dashboard/do_dash_app.py
+++ b/dse_do_dashboard/do_dash_app.py
@@ -383,12 +383,15 @@ class DoDashApp(DashApp):
         inputs = {}
         for scenario_table_name in input_table_names:
             # print(f"read input table {scenario_table_name}")
-            inputs[scenario_table_name] = self.read_scenario_table_from_db_cached(scenario_name, scenario_table_name)
+            # TODO: skip scenario_table_name if not in schema
+            if scenario_table_name in self.dbm.input_db_tables.keys():
+                inputs[scenario_table_name] = self.read_scenario_table_from_db_cached(scenario_name, scenario_table_name)
 
         outputs = {}
         for scenario_table_name in output_table_names:
             # print(f"read output table {scenario_table_name}")
-            outputs[scenario_table_name] = self.read_scenario_table_from_db_cached(scenario_name, scenario_table_name)
+            if scenario_table_name in self.dbm.output_db_tables.keys():
+                outputs[scenario_table_name] = self.read_scenario_table_from_db_cached(scenario_name, scenario_table_name)
         return inputs, outputs
 
     ########################################################################################

--- a/dse_do_dashboard/do_dash_app.py
+++ b/dse_do_dashboard/do_dash_app.py
@@ -358,11 +358,27 @@ class DoDashApp(DashApp):
         Is called from dse_do_dashboard.DoDashApp to create the PlotlyManager."""
 
         if input_table_names is None:
-            # input_table_names = list(self.dbm.input_db_tables.keys())  #This is not consistent with implementation in ScenarioDbManager! Replace by empty list
+            # input_table_names = list(self.dbm.input_db_tables.keys())  # This is not consistent with implementation in ScenarioDbManager! Replace by empty list
             input_table_names = []
             if 'Scenario' in input_table_names: input_table_names.remove('Scenario')  # Remove the scenario table
         if output_table_names is None:  # load all tables by default
             output_table_names = self.dbm.output_db_tables.keys()
+
+        # VT 2022-09-12: Only read tables that exist in schema:
+        # TODO: test and enable this code to handle optional tables in DB, like the Warehouse, WarehouseProperties, etc
+        # input_table_names_in_schema = []
+        # for input_table_name in input_table_names:
+        #     if input_table_name in self.dbm.input_db_tables.keys():
+        #         input_table_names_in_schema.append(input_table_name)
+        #     else:
+        #         print(f"Warning: DODashApp.read_scenario_tables_from_db_cached: input table {input_table_name} not in schema. Table not read.")
+        #
+        # output_table_names_in_schema = []
+        # for output_table_name in output_table_names:
+        #     if output_table_name in self.dbm.output_db_tables.keys():
+        #         output_table_names_in_schema.append(output_table_name)
+        #     else:
+        #         print(f"Warning: DODashApp.read_scenario_tables_from_db_cached: output table {output_table_name} not in schema. Table not read.")
 
         inputs = {}
         for scenario_table_name in input_table_names:

--- a/dse_do_dashboard/main_pages/prepare_data_page_edit.py
+++ b/dse_do_dashboard/main_pages/prepare_data_page_edit.py
@@ -116,6 +116,7 @@ class PrepareDataPageEdit(PrepareDataPage):
             ],
             fixed_rows={'headers': True},
             editable=editable,
+            virtualization=True,
             # fixed_columns={'headers': False, 'data': 0}, # Does NOT create a horizontal scroll bar
             filter_action="native",
             sort_action="native",
@@ -128,7 +129,8 @@ class PrepareDataPageEdit(PrepareDataPage):
                 'font_size': '12px',
                 'textAlign': 'left'},
             style_table={
-                'maxHeight': '400px',
+                'maxHeight': '600px',
+                # 'height': '800',
                 'overflowY': 'scroll'
             },
             style_header={

--- a/dse_do_dashboard/main_pages/prepare_data_page_edit.py
+++ b/dse_do_dashboard/main_pages/prepare_data_page_edit.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Dict
 
 import pandas as pd
 import dash
+from dash.dash_table.Format import Format
 from dash.exceptions import PreventUpdate
 
 from dse_do_dashboard.main_pages.main_page import MainPage

--- a/dse_do_dashboard/utils/dash_common_utils.py
+++ b/dse_do_dashboard/utils/dash_common_utils.py
@@ -18,6 +18,9 @@ import dash_bootstrap_components as dbc
 ##########################################################################
 #  Generic Schema NamedTuple classes
 ##########################################################################
+from dash.dash_table.Format import Format
+
+
 class ForeignKeySchema(NamedTuple):
     table_name: str
     foreign_keys: List[str]
@@ -97,7 +100,7 @@ def get_data_table(df, table_schema: Optional[ScenarioTableSchema] = None, edita
         id=data_table_id,
         data=df.to_dict('records'),
         columns=[
-            {'name': i, 'id': i, 'type': table_type(df[i])}
+            {'name': i, 'id': i, 'type': table_type(df[i])}  # TODO: format 'thousands' separator with: 'format':Format().group(True) or ,  'format': Format(group=',', precision=0)
             for i in df.columns
         ],
         fixed_rows={'headers': True},

--- a/dse_do_dashboard/utils/dash_common_utils.py
+++ b/dse_do_dashboard/utils/dash_common_utils.py
@@ -105,6 +105,7 @@ def get_data_table(df, table_schema: Optional[ScenarioTableSchema] = None, edita
         ],
         fixed_rows={'headers': True},
         editable=editable,
+        virtualization=True,
         # fixed_columns={'headers': False, 'data': 0}, # Does NOT create a horizontal scroll bar
         filter_action="native",
         sort_action="native",
@@ -117,7 +118,7 @@ def get_data_table(df, table_schema: Optional[ScenarioTableSchema] = None, edita
             'font_size': '12px',
             'textAlign': 'left'},
         style_table={
-            'maxHeight': '400px',
+            'maxHeight': '800px',
             'overflowY': 'scroll'
         },
         style_header={
@@ -157,6 +158,7 @@ def get_editable_data_table(df, table_schema: Optional[ScenarioTableSchema]=None
             for i in df.columns
         ],
         fixed_rows={'headers': True},
+        # page_size=20,
         editable=True,
         # fixed_columns={'headers': False, 'data': 0}, # Does NOT create a horizontal scroll bar
         filter_action="native",

--- a/dse_do_dashboard/utils/dash_common_utils.py
+++ b/dse_do_dashboard/utils/dash_common_utils.py
@@ -256,7 +256,7 @@ def get_pivot_table_card_children(df, scenario_name, table_name, pivot_config: O
 
 #####################################
 import functools
-import plotly.express as px
+# import plotly.express as px
 import plotly.graph_objects as go
 import traceback
 

--- a/dse_do_dashboard/utils/domodelrunner.py
+++ b/dse_do_dashboard/utils/domodelrunner.py
@@ -70,8 +70,9 @@ class DoModelRunner(ABC):
         return {}
 
     def update_outputs(self, outputs: Outputs):
-        pass
-        # self.dbm.update_scenario_output_tables_in_db(scenario_name=self.scenario_name, outputs=outputs)
+        # print("Update output tables in DB")
+        self.dbm.update_scenario_output_tables_in_db(scenario_name=self.scenario_name, outputs=outputs)
+        # print("Done update output tables in DB")
 
 
 class DoNotebookModelRunner(DoModelRunner):

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.2b0"
+__version__ = "0.1.2.2b1"

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.2b"
+__version__ = "0.1.2.2b0"

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.1"
+__version__ = "0.1.2.2b"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # For DSE_DO_Dashboard:
-dash~=2.0.0
+dash>=2.0.0
 ## gunicorn==19.9.0  # May not be necessary
 flask_caching==1.10.1
 dash_bootstrap_components==1.0.2

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-version = '0.1.2.1'
+version = '0.1.2.2b'
 
 setuptools.setup(
     name="dse_do_dashboard",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-version = '0.1.2.2b'
+version = '0.1.2.2b1'
 
 setuptools.setup(
     name="dse_do_dashboard",


### PR DESCRIPTION
## [0.1.2.2] - 2022-12-09
### Changed
- setup.py avoids import of dse_do_utils to get __version__
- Removed unused import in dash_common_utils causing failure in PyCharm debug mode

## [0.1.2.2b2] - 2022-11-15
### Changed
- DoDashApp.read_scenario_tables_from_db_cached only reads tables in the schema, skips others without warning.
- Enabled virtualization in DashTables (Prepare data and Explore Solution)
- Remove restriction on SQLAlchemy version < 1.4

## [0.1.2.2b1] - 2022-10-17
### Changed
- DashApp.run_server(self, **kwargs) with arguments for dash app.run_server()
- Enabled write output to DB after run model.
### Removed
- DashApp.set_run_server_kwargs()

## [0.1.2.2b0] - 2022-09-22
### Changed
- Stop Server button now uses os.kill() instead of deprecated Werkzeug callback