### PR TITLE
Releasing V0.1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]## [0.1.2.3b3]
+- dash_app.HostEnvironment is now an IntEnum to allow integer compare
 
 ## [0.1.2.3b2] - 2023-03-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]## [0.1.2.3b4]
+## [Unreleased]## [0.1.2.3b5]
+
+## [0.1.2.3b4] - 2024-04-10
 ### Added
 - PlotlyRowsVisualizationPage adds supports row with just one go.Figure, avoiding list. Makes this compatible with Plotly1ColumnVisualizationPage 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.2.3b3] - 2023-07-05
 - dash_app.HostEnvironment is now an IntEnum to allow integer compare
-- dash_common_utils.diff_dashtable_mi .iteritems() replaced by .items() (Pandas 2.0 deprecated)
+- dash_common_utils.diff_dashtable_mi .iteritems() replaced by .items() (Pandas 2.0 deprecated) 
 
 ## [0.1.2.3b2] - 2023-03-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]## [0.1.2.3b1]
 
-## [0.1.2.b0] - 2023-01-11
+## [0.1.2.3b0] - 2023-01-11
 ### Added
 - DoDashApp support for PostgreSQL database
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]## [0.1.2.3b2]
+### Fixed
+- DoDashApp parameter `db_manager_kwargs` defaults to an empty dict (instead of None)
 
 ## [0.1.2.3b1] - 2023-01-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]## [0.1.2.3b0]
+### Added
+- DoDashApp support for PostgreSQL database
 
 ## [0.1.2.2] - 2022-12-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]## [0.1.2.3b5]
+## [Unreleased]## [0.1.2.3b6]
+
+## [0.1.2.3b5] - 2024-04-15
+### Added
+- PlotlyRowsVisualizationPage.__init__ adds parameters enable_reference_scenario and enable_multi_scenario
 
 ## [0.1.2.3b4] - 2024-04-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]## [0.1.2.3b3]
+## [Unreleased]## [0.1.2.3b4]
+
+## [0.1.2.3b3] - 2023-07-05
 - dash_app.HostEnvironment is now an IntEnum to allow integer compare
+- dash_common_utils.diff_dashtable_mi .iteritems() replaced by .items() (Pandas 2.0 deprecated)
 
 ## [0.1.2.3b2] - 2023-03-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]## [0.1.2.3b1]
+### Added
+- DoDashApp support for additional ScenarioDbManager kwargs
 
 ## [0.1.2.3b0] - 2023-01-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]## [0.1.2.3b1]
+## [Unreleased]## [0.1.2.3b2]
+
+## [0.1.2.3b1] - 2023-01-11
 ### Added
-- DoDashApp support for additional ScenarioDbManager kwargs
+- DoDashApp support for additional ScenarioDbManager kwargs (`db_manager_kwargs`)
 
 ## [0.1.2.3b0] - 2023-01-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]## [0.1.2.3b6]
+### Added
+- DashPlotlyManager: support for scenario kpi compare
 
 ## [0.1.2.3b5] - 2024-04-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]## [0.1.2.3b0]
+## [Unreleased]## [0.1.2.3b1]
+
+## [0.1.2.b0] - 2023-01-11
 ### Added
 - DoDashApp support for PostgreSQL database
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]## [0.1.2.3b2]
+## [Unreleased]## [0.1.2.3b3]
+
+## [0.1.2.3b2] - 2023-03-20
 ### Fixed
 - DoDashApp parameter `db_manager_kwargs` defaults to an empty dict (instead of None)
+### Added
+- DoDashApp support for additional Dash kwargs (`dash_kwargs`)
 
 ## [0.1.2.3b1] - 2023-01-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]## [0.1.2.3b6]
 ### Added
 - DashPlotlyManager: support for scenario kpi compare
+- Visualization page KPIComparePage to automatically compare KPIs
 
 ## [0.1.2.3b5] - 2024-04-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]## [0.1.2.3b6]
+
+## [0.1.2.3] - 2024-11-26
 ### Added
 - DashPlotlyManager: support for scenario kpi compare
 - Visualization page KPIComparePage to automatically compare KPIs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]## [0.1.2.3b4]
+### Added
+- PlotlyRowsVisualizationPage adds supports row with just one go.Figure, avoiding list. Makes this compatible with Plotly1ColumnVisualizationPage 
 
 ## [0.1.2.3b3] - 2023-07-05
 - dash_app.HostEnvironment is now an IntEnum to allow integer compare

--- a/dse_do_dashboard/dash_app.py
+++ b/dse_do_dashboard/dash_app.py
@@ -16,7 +16,7 @@ from dash.long_callback import DiskcacheLongCallbackManager
 
 from dse_do_dashboard.utils.dash_common_utils import ScenarioTableSchema
 
-
+# TODO: use dse_do_utils.scenariomanager.Platform instead?
 class HostEnvironment(enum.Enum):
     Local = 1  # Regular Dash
     CPD402 = 2  # Special handling of port

--- a/dse_do_dashboard/dash_app.py
+++ b/dse_do_dashboard/dash_app.py
@@ -17,7 +17,8 @@ from dash.long_callback import DiskcacheLongCallbackManager
 from dse_do_dashboard.utils.dash_common_utils import ScenarioTableSchema
 
 # TODO: use dse_do_utils.scenariomanager.Platform instead?
-class HostEnvironment(enum.Enum):
+# VT20230412: Changed to IntWenum to allow compare by int value. To avoid circular dependenies.
+class HostEnvironment(enum.IntEnum):
     Local = 1  # Regular Dash
     CPD402 = 2  # Special handling of port
 

--- a/dse_do_dashboard/dash_app.py
+++ b/dse_do_dashboard/dash_app.py
@@ -32,6 +32,7 @@ class DashApp(ABC):
                  bootstrap_theme = dbc.themes.BOOTSTRAP,
                  bootstrap_figure_template: str = "bootstrap",
                  enable_long_running_callbacks: bool = False,
+                 dash_kwargs: Dict = {},
                  ):
         self.port = port
         self.host_env = host_env
@@ -39,7 +40,7 @@ class DashApp(ABC):
         self.bootstrap_theme = bootstrap_theme
         self.set_bootstrap_figure_template(bootstrap_figure_template)
 
-        # Long running callbacks:
+        # Long-running callbacks:
         self.enable_long_running_callbacks = enable_long_running_callbacks
         if self.enable_long_running_callbacks:
             cache = diskcache.Cache("./cache")
@@ -47,6 +48,7 @@ class DashApp(ABC):
         else:
             self.long_callback_manager = None
 
+        self.dash_kwargs = dash_kwargs
         self.app = self.create_dash_app()
 
         # Margins to layout the header, sidebar and content area:
@@ -100,12 +102,14 @@ class DashApp(ABC):
                             # suppress_callback_exceptions = True,
                             assets_folder=assets_path,
                             long_callback_manager=self.long_callback_manager,
+                            **self.dash_kwargs
                             )
         else:
             app = dash.Dash(__name__,
                             # suppress_callback_exceptions = True,
                             assets_folder=assets_path,
                             long_callback_manager=self.long_callback_manager,
+                            **self.dash_kwargs
                             )
         dbc_css = "https://cdn.jsdelivr.net/gh/AnnMarieW/dash-bootstrap-templates/dbc.css"
         app.config.external_stylesheets = [self.bootstrap_theme, dbc_css]

--- a/dse_do_dashboard/dash_plotly_manager.py
+++ b/dse_do_dashboard/dash_plotly_manager.py
@@ -1,0 +1,108 @@
+from typing import Optional, TypeVar, Dict
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objs as go
+from dse_do_utils import DataManager
+from dse_do_utils.plotlymanager import PlotlyManager
+
+DM = TypeVar('DM', bound='DataManager')
+
+
+class DashPlotlyManager(PlotlyManager[DM]):
+
+    def __init__(self, dm: DM):
+        super().__init__(dm)
+
+        self.ref_dm: Optional[DataManager]
+        self.ms_inputs: Optional[Dict[str, pd.DataFrame]]
+        self.ms_outputs: Optional[Dict[str, pd.DataFrame]]
+
+    def plotly_kpi_compare_bar_charts(self, figs_per_row: int = 3, orientation: str = 'v') -> [[go.Figure]]:
+        """
+        Generalized compare of KPIs between scenarios. Creates a list-of-list of go.Figure, i.e. rows of figures,
+        for the PlotlyRowsVisualizationPage.
+        Each KPI gets its own bar-chart, comparing the scenarios.
+
+        Supports 3 cases:
+            1. Multi-scenario compare based on the Reference Scenarios multi-checkbox select on the Home page.
+            2. Compare the current select scenario with the Reference Scenario selected on the Home page.
+            3. Single scenario view based on the currently selected scenario
+
+        Args:
+            figs_per_row: int - Maximum number of figures per row
+            orientation: str - `h' (horizontal) or `v` (vertical)
+
+        Returns:
+            figures in rows ([[go.Figure]]) - bar-charts in rows
+        """
+        # df = self.dm.kpis.reset_index()
+
+        figs = []
+        if self.get_multi_scenario_compare_selected():
+            df = self.get_multi_scenario_table('kpis')
+        elif self.get_reference_scenario_compare_selected():
+            ref_df = self.ref_dm.kpis.reset_index()
+            ref_df['scenario_name'] = 'Reference'
+            selected_df = self.dm.kpis.reset_index()
+            selected_df['scenario_name'] = 'Current'
+            df = pd.concat([selected_df, ref_df])
+        else:
+            df = self.dm.kpis.reset_index()
+            df['scenario_name'] = 'Current'
+
+        for kpi_name, group in df.groupby('NAME'):
+            labels = {'scenario_name': 'Scenario', 'VALUE': kpi_name}
+            title = f'{kpi_name}'
+            if orientation == 'v':
+                fig = px.bar(group, x='scenario_name', y='VALUE', orientation='v', color='scenario_name', labels=labels,
+                             title=title)
+            else:
+                fig = px.bar(group, y='scenario_name', x='VALUE', orientation='h', color='scenario_name',
+                             labels=labels)
+            fig.update_layout(xaxis_title=None)
+            fig.update_layout(yaxis_title=None)
+            fig.update_layout(showlegend=False)
+            figs.append(fig)
+
+        # Split list of figures in list-of-lists with maximum size of n:
+        n = figs_per_row
+        figs = [figs[i:i + n] for i in range(0, len(figs), n)]
+        return figs
+
+    def get_multi_scenario_compare_selected(self) -> bool:
+        """Returns True if the user has selected multi-scenario compare
+        TODO: migrate to dse-do-dashboard (or to some new class in the dse-do-dashboard?)
+        """
+        ms_enabled = (isinstance(self.ms_outputs, dict)
+                      and isinstance(self.ms_inputs, dict)
+                      and 'Scenario' in self.ms_inputs.keys()
+                      and self.ms_inputs['Scenario'].shape[0] > 0
+                      )
+        return ms_enabled
+
+    def get_multi_scenario_table(self, table_name: str) -> Optional[pd.DataFrame]:
+        """Gets the df from the table named `table_name` in either inputs or outputs.
+        Merges the Scenario table, so it has the scenario_name as column.
+        DataFrame is NOT indexed!
+        TODO: migrate to dse-do-dashboard (or to some new class in the dse-do-dashboard?)
+        """
+        if table_name in self.ms_inputs.keys():
+            df = self.ms_inputs[table_name]
+        elif table_name in self.ms_outputs.keys():
+            df = self.ms_outputs[table_name]
+        else:
+            df = None
+
+        if df is not None:
+            df = df.merge(self.ms_inputs['Scenario'], on='scenario_seq')
+
+        return df
+
+    def get_reference_scenario_compare_selected(self) -> bool:
+        """Returns True if the user has selected (single) reference-scenario compare
+        TODO: migrate to dse-do-dashboard (or to some new class in the dse-do-dashboard?)
+        """
+        ms_selected = self.get_multi_scenario_compare_selected()
+        ref_selected = isinstance(self.ref_dm, DataManager)
+        return not ms_selected and ref_selected

--- a/dse_do_dashboard/do_dash_app.py
+++ b/dse_do_dashboard/do_dash_app.py
@@ -53,7 +53,7 @@ class DoDashApp(DashApp):
                  db_echo: Optional[bool] = False,
                  logo_file_name: Optional[str] = 'IBM.png',
                  navbar_brand_name: Optional[str] = 'Dashboard',
-                 cache_config: Optional[Dict]= {},
+                 cache_config: Optional[Dict] = {},
                  visualization_pages: Optional[List[VisualizationPage]]= [],
                  database_manager_class=None,
                  data_manager_class=None,

--- a/dse_do_dashboard/do_dash_app.py
+++ b/dse_do_dashboard/do_dash_app.py
@@ -65,7 +65,8 @@ class DoDashApp(DashApp):
                  bootstrap_figure_template:str="bootstrap",
                  enable_long_running_callbacks: bool = False,
                  db_type: DatabaseType = DatabaseType.DB2,
-                 db_manager_kwargs: Dict = {},  # Do set to None
+                 db_manager_kwargs: Dict = {},  # Do not set to None,
+                 dash_kwargs: Dict = {},
                  ):
         """Create a Dashboard app.
 
@@ -142,7 +143,8 @@ class DoDashApp(DashApp):
                          cache_config=cache_config, port=port,
                          dash_debug=dash_debug, host_env=host_env,
                          bootstrap_theme=bootstrap_theme, bootstrap_figure_template=bootstrap_figure_template,
-                         enable_long_running_callbacks=enable_long_running_callbacks,)
+                         enable_long_running_callbacks=enable_long_running_callbacks,
+                         dash_kwargs=dash_kwargs)
 
     def create_database_manager_instance(self) -> ScenarioDbManager:
         """Create an instance of a ScenarioDbManager.

--- a/dse_do_dashboard/do_dash_app.py
+++ b/dse_do_dashboard/do_dash_app.py
@@ -9,7 +9,7 @@ from dse_do_dashboard.main_pages.home_page_edit import HomePageEdit
 from dse_do_dashboard.main_pages.prepare_data_page_edit import PrepareDataPageEdit
 from dse_do_dashboard.utils.domodelrunner import DoModelRunner, DoModelRunnerConfig
 from dse_do_utils import DataManager
-from dse_do_utils.scenariodbmanager import ScenarioDbManager
+from dse_do_utils.scenariodbmanager import ScenarioDbManager, DatabaseType
 
 from dse_do_dashboard.dash_app import DashApp, HostEnvironment
 from dash import dcc, html, Output, Input, State
@@ -64,6 +64,7 @@ class DoDashApp(DashApp):
                  bootstrap_theme=dbc.themes.BOOTSTRAP,
                  bootstrap_figure_template:str="bootstrap",
                  enable_long_running_callbacks: bool = False,
+                 db_type: DatabaseType = DatabaseType.DB2
                  ):
         """Create a Dashboard app.
 
@@ -89,6 +90,7 @@ class DoDashApp(DashApp):
         self.db_credentials = db_credentials
         self.schema = schema
         self.db_echo = db_echo
+        self.db_type = db_type
         self.database_manager_class = database_manager_class
         # assert issubclass(self.database_manager_class, ScenarioDbManager)
         self.dbm = self.create_database_manager_instance()
@@ -143,8 +145,8 @@ class DoDashApp(DashApp):
         The default implementation uses the database_manager_class from the constructor.
         Optionally, override this method."""
         if self.database_manager_class is not None and self.db_credentials is not None:
-            print(f"Connecting to DB2 at {self.db_credentials['host']}, schema = {self.schema}")
-            dbm = self.database_manager_class(credentials=self.db_credentials, schema=self.schema, echo=self.db_echo)
+            print(f"Connecting to {self.db_type} at {self.db_credentials['host']}, schema = {self.schema}")
+            dbm = self.database_manager_class(credentials=self.db_credentials, schema=self.schema, echo=self.db_echo, db_type = self.db_type)
         else:
             print("Error: either specifiy `database_manager_class`, `db_credentials` and `schema`, or override `create_database_manager_instance`.")
         return dbm

--- a/dse_do_dashboard/do_dash_app.py
+++ b/dse_do_dashboard/do_dash_app.py
@@ -64,7 +64,8 @@ class DoDashApp(DashApp):
                  bootstrap_theme=dbc.themes.BOOTSTRAP,
                  bootstrap_figure_template:str="bootstrap",
                  enable_long_running_callbacks: bool = False,
-                 db_type: DatabaseType = DatabaseType.DB2
+                 db_type: DatabaseType = DatabaseType.DB2,
+                 db_manager_kwargs: Optional[Dict] = None,
                  ):
         """Create a Dashboard app.
 
@@ -91,6 +92,7 @@ class DoDashApp(DashApp):
         self.schema = schema
         self.db_echo = db_echo
         self.db_type = db_type
+        self.db_manager_kwargs = db_manager_kwargs
         self.database_manager_class = database_manager_class
         # assert issubclass(self.database_manager_class, ScenarioDbManager)
         self.dbm = self.create_database_manager_instance()
@@ -134,6 +136,8 @@ class DoDashApp(DashApp):
 
         self.job_queue: List[DoModelRunner] = []  # TODO: migrate to Store. Using global variables is dangerous
 
+
+
         super().__init__(logo_file_name=logo_file_name, navbar_brand_name=navbar_brand_name,
                          cache_config=cache_config, port=port,
                          dash_debug=dash_debug, host_env=host_env,
@@ -146,7 +150,9 @@ class DoDashApp(DashApp):
         Optionally, override this method."""
         if self.database_manager_class is not None and self.db_credentials is not None:
             print(f"Connecting to {self.db_type} at {self.db_credentials['host']}, schema = {self.schema}")
-            dbm = self.database_manager_class(credentials=self.db_credentials, schema=self.schema, echo=self.db_echo, db_type = self.db_type)
+            dbm = self.database_manager_class(credentials=self.db_credentials,
+                                              schema=self.schema, echo=self.db_echo, db_type = self.db_type,
+                                              **self.db_manager_kwargs)
         else:
             print("Error: either specifiy `database_manager_class`, `db_credentials` and `schema`, or override `create_database_manager_instance`.")
         return dbm

--- a/dse_do_dashboard/do_dash_app.py
+++ b/dse_do_dashboard/do_dash_app.py
@@ -9,6 +9,7 @@ from dse_do_dashboard.main_pages.home_page_edit import HomePageEdit
 from dse_do_dashboard.main_pages.prepare_data_page_edit import PrepareDataPageEdit
 from dse_do_dashboard.utils.domodelrunner import DoModelRunner, DoModelRunnerConfig
 from dse_do_utils import DataManager
+from dse_do_utils.datamanager import Inputs, Outputs
 from dse_do_utils.scenariodbmanager import ScenarioDbManager, DatabaseType
 
 from dse_do_dashboard.dash_app import DashApp, HostEnvironment
@@ -362,38 +363,20 @@ class DoDashApp(DashApp):
 
     def read_scenario_tables_from_db_cached(self, scenario_name: str,
                                             input_table_names: List[str] = None,
-                                            output_table_names: List[str] = None):
+                                            output_table_names: List[str] = None) -> (Inputs, Outputs):
         """For use with Flask caching. Loads data for selected input and output tables.
         Same as `read_scenario_tables_from_db`, but calls `read_scenario_table_from_db_cached`.
         Is called from dse_do_dashboard.DoDashApp to create the PlotlyManager."""
 
         if input_table_names is None:
-            # input_table_names = list(self.dbm.input_db_tables.keys())  # This is not consistent with implementation in ScenarioDbManager! Replace by empty list
             input_table_names = []
             if 'Scenario' in input_table_names: input_table_names.remove('Scenario')  # Remove the scenario table
         if output_table_names is None:  # load all tables by default
             output_table_names = self.dbm.output_db_tables.keys()
 
-        # VT 2022-09-12: Only read tables that exist in schema:
-        # TODO: test and enable this code to handle optional tables in DB, like the Warehouse, WarehouseProperties, etc
-        # input_table_names_in_schema = []
-        # for input_table_name in input_table_names:
-        #     if input_table_name in self.dbm.input_db_tables.keys():
-        #         input_table_names_in_schema.append(input_table_name)
-        #     else:
-        #         print(f"Warning: DODashApp.read_scenario_tables_from_db_cached: input table {input_table_name} not in schema. Table not read.")
-        #
-        # output_table_names_in_schema = []
-        # for output_table_name in output_table_names:
-        #     if output_table_name in self.dbm.output_db_tables.keys():
-        #         output_table_names_in_schema.append(output_table_name)
-        #     else:
-        #         print(f"Warning: DODashApp.read_scenario_tables_from_db_cached: output table {output_table_name} not in schema. Table not read.")
-
         inputs = {}
         for scenario_table_name in input_table_names:
             # print(f"read input table {scenario_table_name}")
-            # TODO: skip scenario_table_name if not in schema
             if scenario_table_name in self.dbm.input_db_tables.keys():
                 inputs[scenario_table_name] = self.read_scenario_table_from_db_cached(scenario_name, scenario_table_name)
 

--- a/dse_do_dashboard/do_dash_app.py
+++ b/dse_do_dashboard/do_dash_app.py
@@ -65,7 +65,7 @@ class DoDashApp(DashApp):
                  bootstrap_figure_template:str="bootstrap",
                  enable_long_running_callbacks: bool = False,
                  db_type: DatabaseType = DatabaseType.DB2,
-                 db_manager_kwargs: Dict = {},
+                 db_manager_kwargs: Dict = {},  # Do set to None
                  ):
         """Create a Dashboard app.
 
@@ -92,7 +92,7 @@ class DoDashApp(DashApp):
         self.schema = schema
         self.db_echo = db_echo
         self.db_type = db_type
-        self.db_manager_kwargs = db_manager_kwargs
+        self.db_manager_kwargs = db_manager_kwargs if db_manager_kwargs is not None else {}  # To ensure no None value
         self.database_manager_class = database_manager_class
         # assert issubclass(self.database_manager_class, ScenarioDbManager)
         self.dbm = self.create_database_manager_instance()

--- a/dse_do_dashboard/do_dash_app.py
+++ b/dse_do_dashboard/do_dash_app.py
@@ -65,7 +65,7 @@ class DoDashApp(DashApp):
                  bootstrap_figure_template:str="bootstrap",
                  enable_long_running_callbacks: bool = False,
                  db_type: DatabaseType = DatabaseType.DB2,
-                 db_manager_kwargs: Optional[Dict] = None,
+                 db_manager_kwargs: Dict = {},
                  ):
         """Create a Dashboard app.
 

--- a/dse_do_dashboard/utils/dash_common_utils.py
+++ b/dse_do_dashboard/utils/dash_common_utils.py
@@ -409,7 +409,8 @@ def diff_dashtable_mi(data, data_previous, index_columns: List[str] = None,
         row = row[row.eq(True)]
 
         #         print(f"row={row}")
-        for change in row.iteritems():
+        # for change in row.iteritems():  # Deprecated in Pandas 2.0
+        for change in row.items():
             change = {
                 "row_idx": row_id,
                 "column_name": change[0],

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.3b3"
+__version__ = "0.1.2.3b4"

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.3b1"
+__version__ = "0.1.2.3b2"

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.3b0"
+__version__ = "0.1.2.3b1"

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.3b2"
+__version__ = "0.1.2.3b3"

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.3b4"
+__version__ = "0.1.2.3b5"

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.2"
+__version__ = "0.1.2.3b"

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.3b"
+__version__ = "0.1.2.3b0"

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.3b5"
+__version__ = "0.1.2.3b6"

--- a/dse_do_dashboard/version.py
+++ b/dse_do_dashboard/version.py
@@ -9,4 +9,4 @@ Best practice to keep version here, in a separate file.
 See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 """
 
-__version__ = "0.1.2.3b6"
+__version__ = "0.1.2.3"

--- a/dse_do_dashboard/visualization_pages/folium_column_visualization_page.py
+++ b/dse_do_dashboard/visualization_pages/folium_column_visualization_page.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import List
+from typing import List, Optional
 from dash import html
 
 from dash import dcc
@@ -17,7 +17,8 @@ from dse_do_utils.plotlymanager import PlotlyManager
 class FoliumColumnVisualizationPage(VisualizationPage):
     """Shows one or more folium maps in single column."""
     def __init__(self, dash_app, page_name:str='Default', page_id:str='default', url:str='default',
-                 input_table_names: List[str] = [], output_table_names: List[str] = [],
+                 input_table_names: Optional[List[str]] = None,
+                 output_table_names: Optional[List[str]] = None,
                  enable_reference_scenario: bool = False,
                  enable_multi_scenario: bool = False):
         super().__init__(dash_app=dash_app,

--- a/dse_do_dashboard/visualization_pages/kpi_compare_page.py
+++ b/dse_do_dashboard/visualization_pages/kpi_compare_page.py
@@ -1,0 +1,26 @@
+# Copyright IBM All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+
+from plotly.graph_objs import Figure
+
+from dse_do_dashboard.do_dash_app import DoDashApp
+from dse_do_dashboard.visualization_pages.plotly_rows_visualization_page import PlotlyRowsVisualizationPage
+from dse_do_utils.plotlymanager import PlotlyManager
+
+class KPIComparePage(PlotlyRowsVisualizationPage):
+    def __init__(self, dash_app: DoDashApp):
+        super().__init__(dash_app=dash_app,
+                         page_name='KPI Compare',
+                         page_id='kpi_compare_tab',
+                         url='kpi_compare',
+                         input_table_names=[],
+                         output_table_names=['kpis'],
+                         enable_reference_scenario=True,
+                         enable_multi_scenario=True
+                         )
+
+    def get_plotly_figures(self, pm: PlotlyManager) -> List[Figure]:
+        return pm.plotly_kpi_compare_bar_charts()
+

--- a/dse_do_dashboard/visualization_pages/plotly_rows_visualization_page.py
+++ b/dse_do_dashboard/visualization_pages/plotly_rows_visualization_page.py
@@ -20,13 +20,17 @@ class PlotlyRowsVisualizationPage(VisualizationPage):
     Override the method `get_plotly_figures`.
     """
     def __init__(self, dash_app: DoDashApp, page_name: str = 'Default', page_id: str = 'default', url: str = 'default',
-                 input_table_names: List[str] = [], output_table_names: List[str] = []):
+                 input_table_names: List[str] = [], output_table_names: List[str] = [],
+                 enable_reference_scenario: bool = False,
+                 enable_multi_scenario: bool = False):
         super().__init__(dash_app=dash_app,
                          page_name=page_name,
                          page_id=page_id,
                          url=url,
                          input_table_names=input_table_names,
                          output_table_names=output_table_names,
+                         enable_reference_scenario=enable_reference_scenario,
+                         enable_multi_scenario=enable_multi_scenario,
                          )
 
     @abstractmethod

--- a/dse_do_dashboard/visualization_pages/visualization_page.py
+++ b/dse_do_dashboard/visualization_pages/visualization_page.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
 from dash import html
 # from dse_do_dashboard.do_dash_app import DoDashApp
 from dse_do_dashboard.main_pages.not_found import NotFoundPage
@@ -15,8 +15,10 @@ class VisualizationPage(ABC):
     Subclass should override/implement:
     * get_layout_children(self)
     """
-    def __init__(self, dash_app, page_name:str='Default', page_id:str='default', url:str='default',
-                 input_table_names: List[str] = [], output_table_names: List[str] = [],
+    def __init__(self, dash_app,
+                 page_name: str = 'Default', page_id: str = 'default', url: str = 'default',
+                 input_table_names: Optional[List[str]] = None,
+                 output_table_names: Optional[List[str]] = None,
                  enable_reference_scenario: bool = False,
                  enable_multi_scenario: bool = False):
         """
@@ -36,6 +38,10 @@ class VisualizationPage(ABC):
         TODO:
         * dash_app: DoDashApp. Due to circular imports, cannot specify type!
         """
+        if output_table_names is None:
+            output_table_names = []
+        if input_table_names is None:
+            input_table_names = []
         self.dash_app = dash_app
         self.page_name = page_name  # As shown in UI
         self.page_id = page_id  # Used for Dash pattern-matching callback

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ ibm-db-sa==0.3.7
 
 #For plots:
 folium==0.12.1.post1
-plotly~=5.5.0
+plotly~=5.20.0
 numpy
 
 #notebook runner:
@@ -40,4 +40,7 @@ setuptools
 
 # To avoid error in documentation generator (Spinx)
 ibm_watson_machine_learning
+
+# AG Grid for Dash:
+dash-ag-grid
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ dash_bootstrap_components==1.0.2
 dash-bootstrap-templates==1.0.4
 dash_pivottable==0.0.2
 dash_daq==0.5.0
-sqlalchemy==1.3.23  # 1.3.23 is version in CPD 4.0.2. Also ibm-db-sa doesn't yet fully support 1.4
+sqlalchemy~=1.4
 dse-do-utils>=0.5.4.2
-pandas==1.3.4
+pandas~=1.3.5
 docplex==2.22.213
 openpyxl==3.0.9  # For scenario import and export to .xlsx
 
@@ -24,7 +24,7 @@ ibm-db-sa==0.3.7
 #For plots:
 folium==0.12.1.post1
 plotly~=5.5.0
-numpy~=1.21.5
+numpy
 
 #notebook runner:
 nbformat==5.1.3
@@ -36,6 +36,7 @@ m2r2
 # wheel for building package:
 wheel==0.36.2
 twine
+setuptools
 
 # To avoid error in documentation generator (Spinx)
 ibm_watson_machine_learning


### PR DESCRIPTION
## [0.1.2.3] - 2024-11-26
### Added
- DashPlotlyManager: support for scenario kpi compare
- Visualization page KPIComparePage to automatically compare KPIs

## [0.1.2.3b5] - 2024-04-15
### Added
- PlotlyRowsVisualizationPage.__init__ adds parameters enable_reference_scenario and enable_multi_scenario

## [0.1.2.3b4] - 2024-04-10
### Added
- PlotlyRowsVisualizationPage adds supports row with just one go.Figure, avoiding list. Makes this compatible with Plotly1ColumnVisualizationPage 

## [0.1.2.3b3] - 2023-07-05
- dash_app.HostEnvironment is now an IntEnum to allow integer compare
- dash_common_utils.diff_dashtable_mi .iteritems() replaced by .items() (Pandas 2.0 deprecated) 

## [0.1.2.3b2] - 2023-03-20
### Fixed
- DoDashApp parameter `db_manager_kwargs` defaults to an empty dict (instead of None)
### Added
- DoDashApp support for additional Dash kwargs (`dash_kwargs`)

## [0.1.2.3b1] - 2023-01-11
### Added
- DoDashApp support for additional ScenarioDbManager kwargs (`db_manager_kwargs`)

## [0.1.2.3b0] - 2023-01-11
### Added
- DoDashApp support for PostgreSQL database